### PR TITLE
Update docummentatino - Keyhive warning and some adjustments

### DIFF
--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -3,7 +3,7 @@ layout: default
 title: Sofle Keyboard - build guide (v1/v2)
 ---
 
-This guide suits both v1 and v2. Most of the photos are for v1 and the differences are explained in the text as needed.
+This guide suits both V1 and V2 of the stnadard (**non-RGB**) version of the sofle (The **RGB** version has [dedicated build guide][rgbbuildguide]). Most of the photos are for v1 and the differences are explained in the text as needed.
 
 If you don't have all the necessary parts, please read about [how to source the parts][sourcing].
 
@@ -237,3 +237,4 @@ If you fancy an [inverted silkscreen there's a great guide available](https://gi
 [nooledlag]: https://github.com/qmk/qmk_firmware/issues/7522 "No OLED lag bug"
 [soflegithub]: https://github.com/josefadamcik/SofleKeyboard "SofleKeyboard - KiCad project on Github.com"
 [sourcing]: <{{ site.baseurl }}/sourcing_parts.html> "Sourcing parts"
+[rgbbuildguide]: <{{ site.baseurl }}/build_guide_rgb.html> "Sofle RBG build guide"

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -3,7 +3,9 @@ layout: default
 title: Sofle Keyboard - build guide (v1/v2)
 ---
 
-This guide suits both version **V1** and **V2** of the standard (**non-RGB**) Sofle Keyboardn. The **RGB** version has [dedicated build guide][rgbbuildguide]. Most of the photos are for v1 and the differences are explained in the text as needed.
+This guide suits both version **V1** and **V2** of the standard (**non-RGB**) Sofle Keyboard. Most of the photos are for v1 and the differences are explained in the text as needed.
+
+The **RGB** version has [dedicated build guide][rgbbuildguide].
 
 If you don't have all the necessary parts, please read about [how to source the parts][sourcing].
 

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -3,7 +3,7 @@ layout: default
 title: Sofle Keyboard - build guide (v1/v2)
 ---
 
-This guide suits both V1 and V2 of the stnadard (**non-RGB**) version of the sofle (The **RGB** version has [dedicated build guide][rgbbuildguide]). Most of the photos are for v1 and the differences are explained in the text as needed.
+This guide suits both version **V1** and **V2** of the standard (**non-RGB**) Sofle Keyboardn. The **RGB** version has [dedicated build guide][rgbbuildguide]. Most of the photos are for v1 and the differences are explained in the text as needed.
 
 If you don't have all the necessary parts, please read about [how to source the parts][sourcing].
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -11,11 +11,11 @@ Thise version rolles back the original pro-micro pinout (as for V1) and improves
 
 This build guide is based on a copy of the main [build guide](/docs/build_guide.md). We suggest to revisit the main [build guide](/docs/build_guide.md) for general process and tips about technique. But this build guide is the main source of importand details for your build - like ProMicro orientation, component placement, briding of pads.
 
-**⚠ Keyhive version: Please read if you purchased Sofle RGB from Keyhive**
+**⚠ Keyhive version: Pay attention, if you purchased Sofle RGB from Keyhive**
 
-One bigger vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
+One keyboard vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
 
-**⚠ You have to use the firmware provided by the vendor and build guide provided by them as well. ⚠**
+**⚠ If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.⚠**
 
 Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design.. Contact the vendor instead. In the end, you are their client.
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -11,11 +11,11 @@ Thise version rolles back the original pro-micro pinout (as for V1) and improves
 
 This build guide is based on a copy of the main [build guide](/docs/build_guide.md). We suggest to revisit the main [build guide](/docs/build_guide.md) for general process and tips about technique. But this build guide is the main source of importand details for your build - like ProMicro orientation, component placement, briding of pads.
 
-**⚠ Keyhive version: Pay attention, if you purchased Sofle RGB from Keyhive**
+**&#9888; Keyhive version: Pay attention, if you purchased Sofle RGB from Keyhive**
 
 One keyboard vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
 
-**⚠ If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.**
+**&#9888; If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.**
 
 Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design.. Contact the vendor instead. In the end, you are their client.
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -5,7 +5,7 @@ title: Sofle Keyboard - build guide (RGB)
 
 The Sofle RGB is a copy of the Sofle V2 with the addition of up to 36 RGB leds per side. If you are just looking to try out that layout, and are using the cherry sockets only, then this will work for you. Please mind that the layout has slight modifications, mainly the pinkie stagger is less aggresive than for non-RGB Sofle V2.
 
-Thise version rolles back the original pro-micro pinout (as for V1) and improves routing.
+Thise version rolls back the original pro-micro pinout (to the state it was for V1) and improves routing.
 
 ## This Build Guide
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -15,9 +15,9 @@ This build guide is based on a copy of the main [build guide](/docs/build_guide.
 
 One keyboard vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
 
-**&#9888; If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.**
+**&#9888; If you purchased their modified version, you have to use the firmware provided by the vendor and [the build guide provided by them as well][keyhivebuildguide].**
 
-Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design.. Contact the vendor instead. In the end, you are their client.
+Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design. Contact the vendor instead. In the end, you are their client.
 
 ## Bill of materials
 
@@ -270,3 +270,4 @@ The default layout for the SofleRGB is in the qmk repo, and demonstrates some LE
 [nooledlag]: https://github.com/qmk/qmk_firmware/issues/7522 "No OLED lag bug"
 [soflegithub]: https://github.com/josefadamcik/SofleKeyboard "SofleKeyboard - KiCad project on Github.com"
 [sourcing]: <{{ site.baseurl }}/sourcing_parts.html> "Sourcing parts"
+[keyhivebuildguide]: <https://github.com/keyhive/build_guides/blob/master/docs/keyboards/sofle-rgb.md> "Sofle RGB Keyhive build guide"

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -3,15 +3,22 @@ layout: default
 title: Sofle Keyboard - build guide (RGB)
 ---
 
-The Sofle RGB is a copy of the Sofle v2 with the addition of up to 36 RGB leds per side. If you are just looking to try out that layout, and are using the cherry sockets only, then this will work for you. 
+The Sofle RGB is a copy of the Sofle V2 with the addition of up to 36 RGB leds per side. If you are just looking to try out that layout, and are using the cherry sockets only, then this will work for you. Please mind that the layout has slight modifications, mainly the pinkie stagger is less aggresive than for non-RGB Sofle V2.
 
-I also rolled back to the original pro-micro pinout, and completely redid the routing. 
-
-The OLED placement and OLED cover plate holes have not changed, and a plate has been designed. I haven't yet had one manufactured yet, but will in the next few weeks and refine if needed.
+Thise version rolles back the original pro-micro pinout (as for V1) and improves routing.
 
 ## This Build Guide
 
-For the most part, this guide is the same as the Sofle. I have shamelessly stolen Josef's build guide, and abreviated it heavily to cover mostly the differences. If you need more detail, please refer to the main [build guide](/docs/build_guide.md)
+This build guide is based on a copy of the main [build guide](/docs/build_guide.md). We suggest to revisit the main [build guide](/docs/build_guide.md) for general process and tips about technique. But this build guide is the main source of importand details for your build - like ProMicro orientation, component placement, briding of pads.
+
+**⚠ Keyhive version: Please read if you purchased Sofle RGB from Keyhive**
+
+One bigger vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
+
+**⚠ You have to use the firmware provided by the vendor and build guide provided by them as well. ⚠**
+
+Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design.. Contact the vendor instead. In the end, you are their client.
+
 ## Bill of materials
 
 The following is needed to build the keyboard.

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -5,7 +5,7 @@ title: Sofle Keyboard - build guide (RGB)
 
 The Sofle RGB is a copy of the Sofle V2 with the addition of up to 36 RGB leds per side. If you are just looking to try out that layout, and are using the cherry sockets only, then this will work for you. Please mind that the layout has slight modifications, mainly the pinkie stagger is less aggresive than for non-RGB Sofle V2.
 
-Thise version rolls back the original pro-micro pinout (to the state it was for V1) and improves routing.
+This version rolls back the original pro-micro pinout (to the state it was for V1) and improves routing.
 
 ## This Build Guide
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -9,7 +9,7 @@ This version rolls back the original pro-micro pinout (to the state it was for V
 
 ## This Build Guide
 
-This build guide is based on a copy of the main [build guide](/docs/build_guide.md). We suggest to revisit the main [build guide](/docs/build_guide.md) for general process and tips about technique. But this build guide is the main source of importand details for your build - like ProMicro orientation, component placement, briding of pads.
+This build guide is based on a copy of the main [build guide](/docs/build_guide.md). We suggest to revisit the main [build guide](/docs/build_guide.md) for general process and tips about technique. But this build guide is the main source of importand details for your build - like Pro-Micro orientation, component placement etc.
 
 **&#9888; Keyhive version: Pay attention, if you purchased Sofle RGB from Keyhive**
 

--- a/docs/build_guide_rgb.md
+++ b/docs/build_guide_rgb.md
@@ -15,7 +15,7 @@ This build guide is based on a copy of the main [build guide](/docs/build_guide.
 
 One keyboard vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the **firmware** for the official designs. Also this build guide no longer applies to their version. 
 
-**⚠ If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.⚠**
+**⚠ If you purchased their modified version, you have to use the firmware provided by the vendor and build guide provided by them as well.**
 
 Please, don't report problems with the desing by Keyhive and or firmware to the official Sofle Keyboard repository. Their modification is not part of the repository and therefore we can't fix any problems and we can't help with any problems you might have with the design.. Contact the vendor instead. In the end, you are their client.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Since the development was not moving forward for several months and there were m
 
 ### RGB
 
-**If you bouth Sofle RGB for Keyhive, see below, please.**
+**&#9888; If you bought Sofle RGB from Keyhive, see the disclamer below, please.**
 
 ![SofleKeyboard RGB](images/SofleRGB_1.png)
 
@@ -58,7 +58,7 @@ The OLED placement and OLED cover plate holes have not changed, and a plate has 
 
 [Build guide is available here]({{ baseurl }}/SofleKeyboard/build_guide_rgb.html).
 
-### Keyhive RGB
+###	&#9888; Keyhive RGB
 
 One bigger vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the firmware for the official designs. You have to use the firmware provided by the vendor and build guide provided by them as well. Please, don't report problems with the desing and or firmware to this repository. Their modification is not part of the repository and therefore we cannot fix the problems or help you with solution. Contact the vendor instead. In the end, you are their client.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ The OLED placement and OLED cover plate holes have not changed, and a plate has 
 
 ###	&#9888; Keyhive RGB
 
-One bigger vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the firmware for the official designs. You have to use the firmware provided by the vendor and build guide provided by them as well. Please, don't report problems with the desing and or firmware to this repository. Their modification is not part of the repository and therefore we cannot fix the problems or help you with solution. Contact the vendor instead. In the end, you are their client.
+One keyboard vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the firmware for the official designs. You have to use the firmware provided by the vendor and build guide provided by them as well. Please, don't report problems with the desing and or firmware to this repository. Their modification is not part of the repository and therefore we cannot fix the problems or help you. Contact the vendor instead. In the end, you are their client.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ Since the development was not moving forward for several months and there were m
 
 ### RGB
 
+**If you bouth Sofle RGB for Keyhive, see below, please.**
+
 ![SofleKeyboard RGB](images/SofleRGB_1.png)
 
 Sofle RGB was contributed by [Dane Evans](https://github.com/DaneEvans).
@@ -54,8 +56,11 @@ The original pro-micro pinout was rolled back and routing was redone.
 
 The OLED placement and OLED cover plate holes have not changed, and a plate has been designed. 
 
-
 [Build guide is available here]({{ baseurl }}/SofleKeyboard/build_guide_rgb.html).
+
+### Keyhive RGB
+
+One bigger vendor - Keyhive - is selling their own fork of Sofle RGB. This version is **modified** in way that makes it **incompatible** with the firmware for the official designs. You have to use the firmware provided by the vendor and build guide provided by them as well. Please, don't report problems with the desing and or firmware to this repository. Their modification is not part of the repository and therefore we cannot fix the problems or help you with solution. Contact the vendor instead. In the end, you are their client.
 
 ## License
 


### PR DESCRIPTION
Add warning about the Keyhive RGB fork and incompatibility. Improve some formulations in the docs. Mention the RGB version doesn't have exactly the same layout as V2

closes #105 