### PR TITLE
Updated qmk getting started link in build guide for sofle choc

### DIFF
--- a/docs/build_guide_choc.md
+++ b/docs/build_guide_choc.md
@@ -292,7 +292,7 @@ The default layout for the Sofle Choc is in the QMK fork and demonstrates some L
 [springpinheader]: <https://yushakobo.jp/shop/a01mc-00/> "Spring pin headers - Japanese"
 [qmkprotonc]: https://qmk.fm/proton-c/ "QMK Proton-C"
 [promicrosocketing]: <https://docs.splitkb.com/hc/en-us/articles/360011263059> "How do I socket a microcontroller? by splitkb.com"
-[qmkintro]: <https://beta.docs.qmk.fm/newbs/newbs_getting_started> "QMK getting started"
+[qmkintro]: <https://docs.qmk.fm/#/newbs_getting_started> "QMK getting started"
 [qmkhandedness]: <https://docs.qmk.fm/#/feature_split_keyboard?id=setting-handedness> "QMK firmware - setting handedness"
 [manufacturingproblems]: https://josef-adamcik.cz/electronics/corne-keyboard-build-log.html#manufacturing-at-jlcpcb---update-27112019 "Possible problems when manufacturing top plate for Corne"
 [nooledlag]: https://github.com/qmk/qmk_firmware/issues/7522 "No OLED lag bug"


### PR DESCRIPTION
Fixes issue https://github.com/josefadamcik/SofleKeyboard/issues/172 "A link in Sofle Choc build doc is not available"
